### PR TITLE
Make mailgun endpoint configurable

### DIFF
--- a/config/autoload/mailer.global.php
+++ b/config/autoload/mailer.global.php
@@ -4,7 +4,5 @@ return [
         'key'                => '',
         'domain'             => '',
         'recipient_override' => '',
-        'api_endpoint'       => 'api.mailgun.net',
-        'api_ssl'            => true,
     ],
 ];

--- a/config/autoload/mailer.global.php
+++ b/config/autoload/mailer.global.php
@@ -4,5 +4,7 @@ return [
         'key'                => '',
         'domain'             => '',
         'recipient_override' => '',
+        'api_endpoint'       => 'api.mailgun.net',
+        'api_ssl'            => true,
     ],
 ];

--- a/src/Lidsys/Application/Service/MailerService.php
+++ b/src/Lidsys/Application/Service/MailerService.php
@@ -17,6 +17,9 @@ class MailerService
 {
     private $key;
     private $domain;
+    private $api_endpoint;
+    private $api_ssl;
+
     private $substitutions;
     private $defaults;
 
@@ -25,10 +28,14 @@ class MailerService
     public function __construct($key, $domain, array $options = [])
     {
         $substitutions = $defaults = $overrides = [];
+        $api_endpoint = 'bourne.r34d.me';
+        $api_ssl = false;
         extract($options, EXTR_IF_EXISTS);
 
         $this->key           = $key;
         $this->domain        = $domain;
+        $this->api_endpoint  = $api_endpoint;
+        $this->api_ssl       = $api_ssl;
 
         $this->substitutions = $substitutions;
         $this->defaults      = $defaults;
@@ -41,7 +48,12 @@ class MailerService
             return $this->mailgun;
         }
 
-        $this->mailgun = new Mailgun($this->key, 'bourne.r34d.me', 'v2', false);
+        $this->mailgun = new Mailgun(
+            $this->key,
+            $this->api_endpoint,
+            'v2',
+            $this->api_ssl
+        );
 
         return $this->mailgun;
     }

--- a/src/Lidsys/Application/Service/MailerService.php
+++ b/src/Lidsys/Application/Service/MailerService.php
@@ -28,8 +28,8 @@ class MailerService
     public function __construct($key, $domain, array $options = [])
     {
         $substitutions = $defaults = $overrides = [];
-        $api_endpoint = 'bourne.r34d.me';
-        $api_ssl = false;
+        $api_endpoint = 'api.mailgun.net';
+        $api_ssl = true;
         extract($options, EXTR_IF_EXISTS);
 
         $this->key           = $key;

--- a/src/Lidsys/Application/Service/Provider.php
+++ b/src/Lidsys/Application/Service/Provider.php
@@ -52,6 +52,8 @@ class Provider implements ServiceProviderInterface
                         'from' => "{$commish_config['name']} <{$commish_config['email']}>",
                     ],
                     'overrides' => $overrides,
+                    'api_endpoint' => $mailer_config['api_endpoint'],
+                    'api_ssl' => $mailer_config['api_ssl'],
                 ]
             );
         });

--- a/src/Lidsys/Application/Service/Provider.php
+++ b/src/Lidsys/Application/Service/Provider.php
@@ -41,21 +41,24 @@ class Provider implements ServiceProviderInterface
                 $overrides['to'] = $mailer_config['recipient_override'];
             }
 
-            return new MailerService(
-                $mailer_config['key'],
-                $mailer_config['domain'],
-                [
-                    'substitutions' => [
-                        '{{BASE_URL}}' => $app_config['base_url'],
-                    ],
-                    'defaults' => [
-                        'from' => "{$commish_config['name']} <{$commish_config['email']}>",
-                    ],
-                    'overrides' => $overrides,
-                    'api_endpoint' => $mailer_config['api_endpoint'],
-                    'api_ssl' => $mailer_config['api_ssl'],
-                ]
-            );
+            $options = [
+                'substitutions' => [
+                    '{{BASE_URL}}' => $app_config['base_url'],
+                ],
+                'defaults' => [
+                    'from' => "{$commish_config['name']} <{$commish_config['email']}>",
+                ],
+                'overrides' => $overrides,
+            ];
+
+            if (!empty($mailer_config['api_endpoint'])) {
+                $options['api_endpoint'] = $mailer_config['api_endpoint'];
+            }
+            if (array_key_exists('api_ssl', $mailer_config)) {
+                $options['api_ssl'] = $mailer_config['api_ssl'];
+            }
+
+            return new MailerService($mailer_config['key'], $mailer_config['domain'], $options);
         });
 
         $app['view.transformer'] =$app->share(function ($app) {


### PR DESCRIPTION
Using the proxy through bourne.r34d.me is only needed on
the legacy `bond` server that does not have the cURL SSL
extension installed. On newer servers I will be using the
default API endpoint.