### PR TITLE
Fix checkbox table-cell on picks page

### DIFF
--- a/src/Lidsys/Application/Controller/assets/lidsys/app.css
+++ b/src/Lidsys/Application/Controller/assets/lidsys/app.css
@@ -25,6 +25,7 @@ nav.top-bar .title-area h1 {
     text-align: center;
     vertical-align: middle;
     width: 4%;
+    display: table-cell;
 }
 
 .label.success.wrong-team {


### PR DESCRIPTION
The table cell display is being set to an inline-block
because a label is being applied to it.  Override the
display type to be table-cell.