### PR TITLE
Fix game times generated by football schedule importer

### DIFF
--- a/src/Lidsys/Football/Service/ScheduleImportService.php
+++ b/src/Lidsys/Football/Service/ScheduleImportService.php
@@ -128,6 +128,14 @@ class ScheduleImportService
             $known_data['time'] = $time_div->textContent;
         }
 
+        $time_of_day = $xpath->query(
+            './/span[@class="suff"]/span',
+            $game_li
+        );
+        if ($time_of_day->length && ($time_of_day_div = $time_of_day->item(0))) {
+            $known_data['time_of_day'] = trim($time_of_day_div->textContent);
+        }
+
         return $known_data;
     }
 
@@ -147,7 +155,7 @@ class ScheduleImportService
 
         $raw_time = explode(':', $known_data['time']);
         $time = array(
-            'hour'   => intval($raw_time[0]) + 12,
+            'hour'   => intval($raw_time[0]) + ('PM' === $known_data['time_of_day'] && $raw_time[0] != 12 ? 12 : 0),
             'minute' => intval($raw_time[1]),
         );
 

--- a/src/Lidsys/Football/Service/ScheduleImportService.php
+++ b/src/Lidsys/Football/Service/ScheduleImportService.php
@@ -159,6 +159,8 @@ class ScheduleImportService
             'minute' => intval($raw_time[1]),
         );
 
+        $timezone = date_default_timezone_get();
+        date_default_timezone_set('America/New_York');
         $timestamp  = mktime(
             $time['hour'],
             $time['minute'],
@@ -167,6 +169,7 @@ class ScheduleImportService
             $date['day'],
             $date['year']
         );
+        date_default_timezone_set($timezone);
 
         return $timestamp;
     }


### PR DESCRIPTION
 - Use time of day when setting game time
 - Use NY timezone when creating game's Unix timestamp