### PR TITLE
Exclude probowl week from imports

### DIFF
--- a/src/Lidsys/Football/Service/ScheduleImportService.php
+++ b/src/Lidsys/Football/Service/ScheduleImportService.php
@@ -272,7 +272,9 @@ SQL;
 
         $sql = <<<SQL
 SELECT DISTINCT DATE(gameTime) AS date
-FROM nflGameImport
+FROM nflGameImport AS import
+JOIN nflTeam AS away ON import.awayTeam = away.abbreviation
+JOIN nflTeam AS home ON import.homeTeam = home.abbreviation
 
 UNION DISTINCT
 


### PR DESCRIPTION
The probowl week does not need to be included in imports because the
probowl is not part of our fantasy league.  In order to exclude the
probowl week, we only include weeks that have games with a team that
exists in the database.  The teams 'AFC' and 'NFC' do not exist in the
Lightdatasys database, so the week for the Probowl game is excluded.

Issue #93 