### PR TITLE
Exit on httpie error in backup-maria-dbs

### DIFF
--- a/bin/backup-maria-dbs.sh
+++ b/bin/backup-maria-dbs.sh
@@ -27,7 +27,8 @@ for DATABASE in $(mysql -u "${MYSQL_USER}" -N -e 'show databases'); do
   CURRENT_SNAPSHOT_PATH="${DROPBOX_CURRENT_DIR}/${DATABASE}.sql.gz"
 
   echo -e "\n\nSnapshotting '${DATABASE}' and sending it to Dropbox"
-  mysqldump -u "${MYSQL_USER}" "${DATABASE}" | gzip | http https://content.dropboxapi.com/2/files/upload \
+  mysqldump -u "${MYSQL_USER}" "${DATABASE}" | gzip | http --check-status \
+    https://content.dropboxapi.com/2/files/upload \
     Authorization:"Bearer ${DROPBOX_TOKEN}" \
     Content-Type:application/octet-stream \
     Dropbox-API-Arg:"{\"path\": \"${CURRENT_SNAPSHOT_PATH}\", \"mode\": \"overwrite\", \"mute\": true}"
@@ -36,13 +37,13 @@ for DATABASE in $(mysql -u "${MYSQL_USER}" -N -e 'show databases'); do
     SNAPSHOT_PATH="${HISTORICAL_DIR}/${DATABASE}.sql.gz"
 
     echo -e "\n\nDeleting historical existing ${SNAPSHOT_PATH} snapshot"
-    http --ignore-stdin https://api.dropboxapi.com/2/files/delete_v2 \
+    http --check-status --ignore-stdin https://api.dropboxapi.com/2/files/delete_v2 \
       Authorization:"Bearer ${DROPBOX_TOKEN}" \
       path="${SNAPSHOT_PATH}" \
     || true
 
     echo -e "\n\nCopying current snapshot to ${SNAPSHOT_PATH}"
-    http --ignore-stdin https://api.dropboxapi.com/2/files/copy_v2 \
+    http --check-status --ignore-stdin https://api.dropboxapi.com/2/files/copy_v2 \
       Authorization:"Bearer ${DROPBOX_TOKEN}" \
       from_path="${CURRENT_SNAPSHOT_PATH}" \
       to_path="${SNAPSHOT_PATH}"
@@ -52,6 +53,6 @@ for DATABASE in $(mysql -u "${MYSQL_USER}" -N -e 'show databases'); do
 done
 
 echo -e "\n\nNotifying Honeybadger of completion"
-http --ignore-stdin "${HONEYBADGER_MARIA_BACKUPS_CHECKIN}"
+http --check-status --ignore-stdin "${HONEYBADGER_MARIA_BACKUPS_CHECKIN}"
 
 echo -en "\n\n--\n\nAll done @ $(date)\n\n"


### PR DESCRIPTION
If an HTTP error occurred, the script would just keep running and mark
the backups as successful.  This is a problem since failed HTTP requests
probably means the backup was not successfully stored in Dropbox.