### PR TITLE
Fix Postgres snapshot Honeybadger check-in

### DIFF
--- a/bin/snapshot-postgres
+++ b/bin/snapshot-postgres
@@ -42,6 +42,6 @@ for HISTORICAL_DIR in "${HISTORICAL_DIRS[@]}"; do
 done
 
 echo -e "\n\nNotifying Honeybadger of completion"
-http --check-status --ignore-stdin "${HONEYBADGER_MARIA_BACKUPS_CHECKIN}"
+http --check-status --ignore-stdin "${HONEYBADGER_POSTGRES_SNAPSHOTS_CHECKIN}"
 
 echo -en "\n\n--\n\nAll done @ $(date)\n\n"


### PR DESCRIPTION
It was trying to use the Honeybadger check-in for the MariaDB backups,
but fortunately that environment variable is not available in the
postgres-snapshot container.